### PR TITLE
Set default error callback to prevent SIGABORT

### DIFF
--- a/Secp256k1.Net.Test/Secp256k1.Net.Test.csproj
+++ b/Secp256k1.Net.Test/Secp256k1.Net.Test.csproj
@@ -1,18 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Secp256k1.Net.Test/Tests.cs
+++ b/Secp256k1.Net.Test/Tests.cs
@@ -216,6 +216,30 @@ namespace Secp256k1Net.Test
                 Assert.Equal("0x3a2361270fb1bdd220a2fa0f187cc6f85079043a56fb6a968dfad7d7032b07b01213e80ecd4fb41f1500f94698b1117bc9f3335bde5efbb1330271afc6e85e92", serializedKey.ToHexString(), true);
             }
         }
+    
+        [Fact]
+        public void SigAbortTest()
+        {
+            using (var secp256k1 = new Secp256k1())
+            {
+
+                BigInteger ecdsa_r = BigInteger.Parse("68932463183462156574914988273446447389145511361487771160486080715355143414637");
+                BigInteger ecdsa_s = BigInteger.Parse("47416572686988136438359045243120473513988610648720291068939984598262749281683");
+
+                byte[] ecdsa_r_bytes = BigIntegerConverter.GetBytes(ecdsa_r);
+                byte[] ecdsa_s_bytes = BigIntegerConverter.GetBytes(ecdsa_s);
+                var signature = ecdsa_r_bytes.Concat(ecdsa_s_bytes).ToArray();
+
+                // Allocate memory for the signature and create a serialized-format signature to deserialize into our native format (platform dependent, hence why we do this).
+                Span<byte> serializedSignature = ecdsa_r_bytes.Concat(ecdsa_s_bytes).ToArray();
+                signature = new byte[Secp256k1.UNSERIALIZED_SIGNATURE_SIZE];
+                byte recoveryId = 9; // incorrect recoveryId,  it should be >=0 and <=3
+                // We get SIGABORT here with default error callback  
+                var result = secp256k1.RecoverableSignatureParseCompact(signature, serializedSignature, recoveryId);
+                Assert.False(result);
+                
+            }
+        }
     }
 
     public static class Extensions

--- a/Secp256k1.Net/Interop.cs
+++ b/Secp256k1.Net/Interop.cs
@@ -13,7 +13,34 @@ namespace Secp256k1Net
     /// <returns>a newly created context object.</returns>
     [SymbolName(nameof(secp256k1_context_create))]
     public delegate IntPtr secp256k1_context_create(uint flags);
+    
+    
+    /// <summary>
+    /// Type for error and illegal callback functions,
+    /// </summary>
+    /// <param name="message">message: error message.</param>
+    /// <param name="data">data: callback marker, it is set by user together with callback.</param>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public unsafe delegate void CsDelegateForCFunctionT(String message, void* data);
+    
+    /// <summary>
+    /// Sets and illegal calback for secp256k1 context object. This callback is called fo illegal operations.
+    /// </summary>
+    /// <param name="ctx">ctx: an existing context to destroy (cannot be NULL).</param>
+    /// <param name="fun">fun: illegal callback function.</param>
+    /// <param name="data">data: callback marker, it is set by user together with callback.</param>
+    [SymbolName(nameof(secp256k1_context_set_illegal_callback))]
+    public unsafe delegate void secp256k1_context_set_illegal_callback(IntPtr ctx, CsDelegateForCFunctionT fun, void* data);
 
+    /// <summary>
+    /// Sets and error callback for secp256k1 context object. This callback is called for errors.
+    /// </summary>
+    /// <param name="ctx">ctx: an existing context to destroy (cannot be NULL).</param>
+    /// <param name="fun">fun: illegal callback function.</param>
+    /// <param name="data">data: callback marker, it is set by user together with callback.</param>
+    [SymbolName(nameof(secp256k1_context_set_error_callback))]
+    public unsafe delegate void secp256k1_context_set_error_callback(IntPtr ctx, CsDelegateForCFunctionT fun, void* data);
+    
     /// <summary>
     /// Destroy a secp256k1 context object. The context pointer may not be used afterwards.
     /// </summary>

--- a/Secp256k1.Net/Interop.cs
+++ b/Secp256k1.Net/Interop.cs
@@ -21,7 +21,7 @@ namespace Secp256k1Net
     /// <param name="message">message: error message.</param>
     /// <param name="data">data: callback marker, it is set by user together with callback.</param>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void CsDelegateForCFunctionT(String message, void* data);
+    public unsafe delegate void ErrorCallbackDelegate(string message, void* data);
     
     /// <summary>
     /// Sets and illegal calback for secp256k1 context object. This callback is called fo illegal operations.
@@ -30,7 +30,7 @@ namespace Secp256k1Net
     /// <param name="fun">fun: illegal callback function.</param>
     /// <param name="data">data: callback marker, it is set by user together with callback.</param>
     [SymbolName(nameof(secp256k1_context_set_illegal_callback))]
-    public unsafe delegate void secp256k1_context_set_illegal_callback(IntPtr ctx, CsDelegateForCFunctionT fun, void* data);
+    public unsafe delegate void secp256k1_context_set_illegal_callback(IntPtr ctx, ErrorCallbackDelegate fun, void* data);
 
     /// <summary>
     /// Sets and error callback for secp256k1 context object. This callback is called for errors.
@@ -39,7 +39,7 @@ namespace Secp256k1Net
     /// <param name="fun">fun: illegal callback function.</param>
     /// <param name="data">data: callback marker, it is set by user together with callback.</param>
     [SymbolName(nameof(secp256k1_context_set_error_callback))]
-    public unsafe delegate void secp256k1_context_set_error_callback(IntPtr ctx, CsDelegateForCFunctionT fun, void* data);
+    public unsafe delegate void secp256k1_context_set_error_callback(IntPtr ctx, ErrorCallbackDelegate fun, void* data);
     
     /// <summary>
     /// Destroy a secp256k1 context object. The context pointer may not be used afterwards.

--- a/Secp256k1.Net/Secp256k1.Net.csproj
+++ b/Secp256k1.Net/Secp256k1.Net.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Secp256k1.Native" Version="0.1.24-alpha" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <Target Name="PackTaskDependencies" BeforeTargets="GenerateNuspec">

--- a/Secp256k1.Net/Secp256k1.cs
+++ b/Secp256k1.Net/Secp256k1.cs
@@ -88,16 +88,25 @@ namespace Secp256k1Net
             secp256k1_ecdh = LazyDelegate<secp256k1_ecdh>();
 
             _ctx = secp256k1_context_create.Value(((uint)(Flags.SECP256K1_CONTEXT_SIGN | Flags.SECP256K1_CONTEXT_VERIFY)));
-
-            _error_callback = DefaultErrorCallback;
-            secp256k1_context_set_illegal_callback.Value(_ctx, _error_callback, null);
-            secp256k1_context_set_error_callback.Value(_ctx, _error_callback, null);
+            SetErrorCallback(DefaultErrorCallback, null);
         }
 
         Lazy<TDelegate> LazyDelegate<TDelegate>()
         {
             var symbol = SymbolNameCache<TDelegate>.SymbolName;
             return new Lazy<TDelegate>(() => LoadLibNative.GetDelegate<TDelegate>(_libPtr.Value, symbol), isThreadSafe: false);
+        }
+
+        /// <summary>
+        /// Sets user-defined error calback for this context.
+        /// </summary>
+        /// <param name="cb">User-defined callback, it is called in the case of the error or illegal operation.</param>
+        /// <param name="data">User-defined callback marker, it is passed as second argument when callback is called.</param>
+        public void SetErrorCallback(CsDelegateForCFunctionT cb, void* data)
+        {
+            _error_callback = cb;
+            secp256k1_context_set_illegal_callback.Value(_ctx, _error_callback, data);
+            secp256k1_context_set_error_callback.Value(_ctx, _error_callback, data);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves https://github.com/zone117x/Secp256k1.Net/issues/16

First commit adds the test to reproduce the issue.
Second commit adds default error callback. I've failed to find the useful callback implementation, throwing an exception for error for example (we can't throw from callback itself,  and saving error message in some struct can change the way this class can be used due to multithreading issues for example),  so I just added ability to set user-defined callback in the third commit.

Tell me please if you don't like anything,  I'll try to fix it. 

I've tested this implementation on Linux only.