### PR TITLE
test: test compatible with net framework 4.6.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,3 +39,16 @@ jobs:
         with:
           files: "**/TestResults/*/*.cobertura.xml"
           verbose: true
+
+  test-net-framework:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: dotnet build Secp256k1.Net.Test --configuration Release --framework net461
+      - name: Test
+        run: dotnet vstest Secp256k1.Net.Test\bin\Release\net461\Secp256k1.Net.Test.dll /Framework:".NETFramework,Version=v4.6.1" /Platform:"x64" --collect:"XPlat Code Coverage"
+      - uses: codecov/codecov-action@v3
+        with:
+          files: "**/TestResults/*/*.cobertura.xml"
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,13 +42,15 @@ jobs:
 
   test-net-framework:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, x86]
     steps:
       - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: dotnet restore Secp256k1.Net.Test
       - name: Build
-        run: dotnet build Secp256k1.Net.Test --configuration Release --framework net461
+        run: dotnet build Secp256k1.Net.Test --configuration Release --framework net461 --no-restore
       - name: Test
-        run: dotnet vstest Secp256k1.Net.Test\bin\Release\net461\Secp256k1.Net.Test.dll /Framework:".NETFramework,Version=v4.6.1" /Platform:"x64" --collect:"XPlat Code Coverage"
-      - uses: codecov/codecov-action@v3
-        with:
-          files: "**/TestResults/*/*.cobertura.xml"
-          verbose: true
+        run: dotnet vstest Secp256k1.Net.Test\bin\Release\net461\Secp256k1.Net.Test.dll /Framework:".NETFramework,Version=v4.6.1" /Platform:"${{ matrix.arch }}"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ while (!secp256k1.SecretKeyVerify(privateKey));
 
 // Derive public key bytes
 var publicKey = new byte[Secp256k1.PUBKEY_LENGTH];
-Assert.True(secp256k1.PublicKeyCreate(publicKey, privateKey), "Public key creation failed");
+Assert.True(secp256k1.PublicKeyCreate(publicKey, privateKey));
 
 // Serialize the public key to compressed format
 var serializedCompressedPublicKey = new byte[Secp256k1.SERIALIZED_COMPRESSED_PUBKEY_LENGTH];
@@ -32,6 +32,16 @@ Assert.True(secp256k1.PublicKeySerialize(serializedCompressedPublicKey, publicKe
 // Serialize the public key to uncompressed format
 var serializedUncompressedPublicKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
 Assert.True(secp256k1.PublicKeySerialize(serializedUncompressedPublicKey, publicKey, Flags.SECP256K1_EC_UNCOMPRESSED));
+
+// Parse public key from serialized compressed public key
+var parsedPublicKey1 = new byte[Secp256k1.PUBKEY_LENGTH];
+Assert.IsTrue(secp256k1.PublicKeyParse(parsedPublicKey1, serializedCompressedPublicKey));
+Assert.AreEqual(Convert.ToHexString(publicKey), Convert.ToHexString(parsedPublicKey1));
+
+// Parse public key from serialied uncompressed public key
+var parsedPublicKey2 = new byte[Secp256k1.PUBKEY_LENGTH];
+Assert.IsTrue(secp256k1.PublicKeyParse(parsedPublicKey2, serializedUncompressedPublicKey));
+Assert.AreEqual(Convert.ToHexString(publicKey), Convert.ToHexString(parsedPublicKey2));
 ```
 
 #### Sign and verify message

--- a/Secp256k1.Net.Test/Secp256k1.Net.Test.csproj
+++ b/Secp256k1.Net.Test/Secp256k1.Net.Test.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net461</TargetFrameworks>
-		<LangVersion>10.0</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RootNamespace>Secp256k1Net.Test</RootNamespace>

--- a/Secp256k1.Net.Test/Secp256k1.Net.Test.csproj
+++ b/Secp256k1.Net.Test/Secp256k1.Net.Test.csproj
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-        <ImplicitUsings>enable</ImplicitUsings>
+        <TargetFrameworks>net6.0;net7.0;net461</TargetFrameworks>
+		<LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RootNamespace>Secp256k1Net.Test</RootNamespace>
+        <OutputType>Library</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />

--- a/Secp256k1.Net.Test/Tests.cs
+++ b/Secp256k1.Net.Test/Tests.cs
@@ -133,6 +133,16 @@ namespace Secp256k1Net.Test
             // Serialize the public key to uncompressed format
             var serializedUncompressedPublicKey = new byte[Secp256k1.SERIALIZED_UNCOMPRESSED_PUBKEY_LENGTH];
             Assert.IsTrue(secp256k1.PublicKeySerialize(serializedUncompressedPublicKey, publicKey, Flags.SECP256K1_EC_UNCOMPRESSED));
+
+            // Parse public key from serialized compressed public key
+            var parsedPublicKey1 = new byte[Secp256k1.PUBKEY_LENGTH];
+            Assert.IsTrue(secp256k1.PublicKeyParse(parsedPublicKey1, serializedCompressedPublicKey));
+            Assert.AreEqual(Convert.ToHexString(publicKey), Convert.ToHexString(parsedPublicKey1));
+
+            // Parse public key from serialied uncompressed public key
+            var parsedPublicKey2 = new byte[Secp256k1.PUBKEY_LENGTH];
+            Assert.IsTrue(secp256k1.PublicKeyParse(parsedPublicKey2, serializedUncompressedPublicKey));
+            Assert.AreEqual(Convert.ToHexString(publicKey), Convert.ToHexString(parsedPublicKey2));
         }
 
         [TestMethod]

--- a/Secp256k1.Net.Test/Tests.cs
+++ b/Secp256k1.Net.Test/Tests.cs
@@ -1,4 +1,9 @@
-﻿namespace Secp256k1Net.Test
+﻿using System;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Secp256k1Net.Test
 {
     [TestClass]
     public class Tests
@@ -10,8 +15,9 @@
             using var secp256k1 = new Secp256k1();
 
             // Generate a private key
-            byte[] privateKey;
-            do privateKey = System.Security.Cryptography.RandomNumberGenerator.GetBytes(Secp256k1.PRIVKEY_LENGTH);
+            var privateKey = new byte[Secp256k1.PRIVKEY_LENGTH];
+            var rnd = System.Security.Cryptography.RandomNumberGenerator.Create();
+            do { rnd.GetBytes(privateKey); }
             while (!secp256k1.SecretKeyVerify(privateKey));
 
             // Create public key from private key
@@ -24,7 +30,7 @@
 
             // Sign a message hash
             var messageBytes = System.Text.Encoding.UTF8.GetBytes("Hello world.");
-            var messageHash = System.Security.Cryptography.SHA256.HashData(messageBytes);
+            var messageHash = System.Security.Cryptography.SHA256.Create().ComputeHash(messageBytes);
             var signature = new byte[Secp256k1.SIGNATURE_LENGTH];
             Assert.IsTrue(secp256k1.Sign(signature, messageHash, privateKey));
 
@@ -140,7 +146,7 @@
             };
 
             var msgBytes = System.Text.Encoding.UTF8.GetBytes("Hello!!");
-            var msgHash = System.Security.Cryptography.SHA256.HashData(msgBytes);
+            var msgHash = System.Security.Cryptography.SHA256.Create().ComputeHash(msgBytes);
             Assert.AreEqual(Secp256k1.HASH_LENGTH, msgHash.Length);
 
             var signature = new byte[Secp256k1.SIGNATURE_LENGTH];
@@ -318,7 +324,7 @@
         public void NativeLibResolveLoadClose()
         {
             var origLibPath = LibPathResolver.Resolve(Secp256k1.LIB);
-            var tempLibPath = Path.GetTempFileName();
+            var tempLibPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             try
             {
                 File.Copy(origLibPath, tempLibPath, overwrite: true);
@@ -357,7 +363,7 @@
         {
             var exception = Assert.ThrowsException<Exception>(() =>
             {
-                LoadLibNative.CloseLibrary(IntPtr.MaxValue);
+                LoadLibNative.CloseLibrary(new IntPtr(int.MaxValue));
             });
             StringAssert.Contains(exception.Message, "closing failed");
         }
@@ -374,4 +380,20 @@
             StringAssert.Contains(exception.Message, "symbol failed");
         }
     }
+
+#if !NET5_0_OR_GREATER
+    static class Convert
+    {
+        public static byte[] FromHexString(string s)
+        {
+            return Enumerable.Range(0, s.Length / 2).Select(x => System.Convert.ToByte(s.Substring(x * 2, 2), 16)).ToArray();
+        }
+
+        public static string ToHexString(ReadOnlySpan<byte> bytes)
+        {
+            return BitConverter.ToString(bytes.ToArray()).Replace("-", "");
+        }
+    }
+#endif
+
 }

--- a/Secp256k1.Net.Test/Usings.cs
+++ b/Secp256k1.Net.Test/Usings.cs
@@ -1,1 +1,0 @@
-﻿global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/Secp256k1.Net/Interop.cs
+++ b/Secp256k1.Net/Interop.cs
@@ -286,9 +286,12 @@ namespace Secp256k1Net
         void* output,   // unsigned char *output
         void* pubkey,   // const secp256k1_pubkey *pubkey
         void* privkey,  // const unsigned char *privkey
-        IntPtr hashfp,  // secp256k1_ecdh_hash_function hashfp,
+        secp256k1_ecdh_hash_function hashfp,  // secp256k1_ecdh_hash_function hashfp,
         IntPtr data      // void *data
     );
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public unsafe delegate int secp256k1_ecdh_hash_function(void* output, void* x, void* y, IntPtr data);
 
     // Flags copied from
     // https://github.com/bitcoin-core/secp256k1/blob/452d8e4d2a2f9f1b5be6b02e18f1ba102e5ca0b4/include/secp256k1.h#L157

--- a/Secp256k1.Net/Secp256k1.Net.csproj
+++ b/Secp256k1.Net/Secp256k1.Net.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
         <Company />

--- a/Secp256k1.Net/Secp256k1.cs
+++ b/Secp256k1.Net/Secp256k1.cs
@@ -521,12 +521,9 @@ namespace Secp256k1Net
                 pubPtr = &MemoryMarshal.GetReference(publicKey),
                 privPtr = &MemoryMarshal.GetReference(privateKey))
             {
-                return secp256k1_ecdh.Value(_ctx, resPtr, pubPtr, privPtr, IntPtr.Zero, IntPtr.Zero) == 1;
+                return secp256k1_ecdh.Value(_ctx, resPtr, pubPtr, privPtr, null, IntPtr.Zero) == 1;
             }
         }
-
-
-        delegate int secp256k1_ecdh_hash_function(void* output, void* x, void* y, IntPtr data);
 
         /// <summary>
         /// Compute an EC Diffie-Hellman secret in constant time.
@@ -562,20 +559,11 @@ namespace Secp256k1Net
                 return hashFunction(outputSpan, xSpan, ySpan, d);
             };
 
-            GCHandle gch = GCHandle.Alloc(hashFunctionPtr);
-            try
+            fixed (byte* resPtr = &MemoryMarshal.GetReference(resultOutput),
+                pubPtr = &MemoryMarshal.GetReference(publicKey),
+                privPtr = &MemoryMarshal.GetReference(privateKey))
             {
-                var fp = Marshal.GetFunctionPointerForDelegate(hashFunctionPtr);
-                fixed (byte* resPtr = &MemoryMarshal.GetReference(resultOutput),
-                    pubPtr = &MemoryMarshal.GetReference(publicKey),
-                    privPtr = &MemoryMarshal.GetReference(privateKey))
-                {
-                    return secp256k1_ecdh.Value(_ctx, resPtr, pubPtr, privPtr, fp, data) == 1;
-                }
-            }
-            finally
-            {
-                gch.Free();
+                return secp256k1_ecdh.Value(_ctx, resPtr, pubPtr, privPtr, hashFunctionPtr, data) == 1;
             }
         }
 


### PR DESCRIPTION
* Closes https://github.com/zone117x/Secp256k1.Net/issues/26
* Adds CI testing for .NET Framework 4.6.1 on Windows